### PR TITLE
fix --enable-git-build-id for vpath build

### DIFF
--- a/aldor/configure.ac
+++ b/aldor/configure.ac
@@ -28,7 +28,7 @@ AC_ARG_ENABLE([libraries],
                               [Do not build Aldor libraries])],
               [AM_CONDITIONAL(BUILD_LIBS, false)],
               [AM_CONDITIONAL(BUILD_LIBS, true)])
- 
+
 AC_CHECK_PROGS([JAVAC], [javac], [no])
 AC_ARG_ENABLE([java],
               [AS_HELP_STRING([--disable-java],
@@ -64,12 +64,12 @@ AC_ARG_ENABLE([git-build-id],
               [AS_HELP_STRING([--enable-git-build-id],
                               [Force git sha1 hash as build id])],
               [git_build_id=],
-              [git_build_id=`git status --porcelain 2>&1`])
+              [git_build_id=`cd $srcdir; git status --porcelain 2>&1`])
 
 # Git SHA1 hash as ld build-id.
 AC_MSG_CHECKING([build id])
 if test -z "$git_build_id"; then
-   VCSVERSION=`git rev-parse HEAD`
+   VCSVERSION=`cd $srcdir; git rev-parse HEAD`
    build_id="-Wl,--build-id=0x$VCSVERSION"
    AC_MSG_RESULT([git: $VCSVERSION])
 else


### PR DESCRIPTION
Out-of-source build did not fetch the git-id.
