### PR TITLE
Fix for subdir-objects warning

### DIFF
--- a/aldor/aldor/lib/libfoam/Makefile.am
+++ b/aldor/aldor/lib/libfoam/Makefile.am
@@ -2,27 +2,31 @@ SUBDIRS = al
 
 aldorsrcdir = $(top_srcdir)/aldor/src
 
+runtime_CFLAGS = -I $(aldorsrcdir)
+
 runtime_ALDOR = al/runtime.c
 runtime_CSOURCES =			\
-	$(aldorsrcdir)/btree.c		\
-	$(aldorsrcdir)/compopt.c	\
-	$(aldorsrcdir)/dword.c		\
-	$(aldorsrcdir)/foam_c.c		\
-	$(aldorsrcdir)/foam_cfp.c	\
-	$(aldorsrcdir)/foamopt.c	\
-	$(aldorsrcdir)/opsys.c		\
-	$(aldorsrcdir)/output.c		\
-	$(aldorsrcdir)/stdc.c		\
-	$(aldorsrcdir)/store.c		\
-	$(aldorsrcdir)/table.c		\
-	$(aldorsrcdir)/timer.c		\
-	$(aldorsrcdir)/util.c		\
-	$(aldorsrcdir)/xfloat.c  	
+	btree.c		\
+	compopt.c	\
+	dword.c		\
+	foam_c.c		\
+	foam_cfp.c	\
+	foamopt.c	\
+	opsys.c		\
+	output.c		\
+	stdc.c		\
+	store.c		\
+	table.c		\
+	timer.c		\
+	util.c		\
+	xfloat.c
 
 AM_CFLAGS = -I$(aldorsrcdir) -DFOAM_RTS
 
 lib_LIBRARIES =
 
+$(runtime_CSOURCES): %.c: $(aldorsrcdir)/%.c
+	cp $< $@
 
 #############################################################################
 # :: Built-in bigint
@@ -36,6 +40,11 @@ libfoam_a_SOURCES =			\
 	$(runtime_ALDOR)		\
 	$(runtime_CSOURCES)
 
+bigint.c: $(aldorsrcdir)/bigint.c
+	cp $< $@
+
+foam_i.c: $(aldorsrcdir)/foam_i.c
+	cp $< $@
 
 #############################################################################
 # :: GMP for bigint

--- a/aldor/aldor/subcmd/unitools/Makefile.am
+++ b/aldor/aldor/subcmd/unitools/Makefile.am
@@ -2,30 +2,34 @@
 noinst_LIBRARIES = libport.a
 s = $(srcdir)/../../src
 
-libport_a_SOURCES =	\
-	$s/bigint.c	\
-	$s/btree.c	\
-	$s/buffer.c	\
-	$s/cfgfile.c	\
-	$s/compopt.c	\
-	$s/debug.c	\
-	$s/dword.c	\
-	$s/file.c	\
-	$s/fluid.c	\
-	$s/fname.c	\
-	$s/format.c	\
-	$s/int.c	\
-	$s/list.c	\
-	$s/memclim.c	\
-	$s/opsys.c	\
-	$s/ostream.c	\
-	$s/stdc.c	\
-	$s/store.c	\
-	$s/strops.c	\
-	$s/timer.c	\
-	$s/util.c	\
-	$s/xfloat.c
+libport_a_CFLAGS = -I $s
 
+libport_a_SOURCES =	\
+	bigint.c	\
+	btree.c	\
+	buffer.c	\
+	cfgfile.c	\
+	compopt.c	\
+	debug.c	\
+	dword.c	\
+	file.c	\
+	fluid.c	\
+	fname.c	\
+	format.c	\
+	int.c	\
+	list.c	\
+	memclim.c	\
+	opsys.c	\
+	ostream.c	\
+	stdc.c	\
+	store.c	\
+	strops.c	\
+	timer.c	\
+	util.c	\
+	xfloat.c
+
+$(libport_a_SOURCES): %.c: $s/%.c
+	cp $< $@
 
 # C compiler driver
 bin_PROGRAMS = unicl

--- a/aldor/configure.ac
+++ b/aldor/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_SRCDIR([aldor/src/main.c])
 AC_CONFIG_AUX_DIR([amaux])
 
 # Automake
-AM_INIT_AUTOMAKE([foreign silent-rules parallel-tests color-tests])
+AM_INIT_AUTOMAKE([foreign silent-rules parallel-tests color-tests subdir-objects])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([enable])
 


### PR DESCRIPTION
Not sure if this is the right approach - basically copy files into the local directory before building.

Not sure if there's any versioning issues (eg. subdir objects not being supported in some cases), but it works locally.
