### PR TITLE
Revert "tools: Drop definition of datadir"

### DIFF
--- a/aldor/aldor/tools/unix/aldor.in
+++ b/aldor/aldor/tools/unix/aldor.in
@@ -4,6 +4,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libexecdir=@libexecdir@
 includedir=@includedir@
+datadir=@datadir@
 
 EXEEXT=@EXEEXT@
 

--- a/aldor/aldor/tools/unix/gdb-aldor.in
+++ b/aldor/aldor/tools/unix/gdb-aldor.in
@@ -4,6 +4,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libexecdir=@libexecdir@
 includedir=@includedir@
+datadir=@datadir@
 
 EXEEXT=@EXEEXT@
 


### PR DESCRIPTION
This reverts commit de3a839d30b0dcff55bde9fa1cbbad965f302e7c.

datadir was used implicitly