### PR TITLE
Update CI to upload binary packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,20 @@ jobs:
     - name: build
       run: dpkg-buildpackage -b -us -uc
 
+    - name: Create artifact archives
+      run: |
+        cd debian && rm -rf aldor/DEBIAN && tar zcf aldor-linux-x86_64-${{ github.sha }}.tar.gz aldor/
+        mv aldor-linux-x86_64-${{ github.sha }}.tar.gz ../
+        mv ../../aldor_1.3.0+20190802_amd64.deb ../
+
+    - name: Upload Linux binaries
+      uses: actions/upload-artifact@v4
+      with:
+        name: aldor-linux-x86_64-binary
+        path: |
+          aldor-linux-x86_64-${{ github.sha }}.tar.gz
+          aldor_1.3.0+20190802_amd64.deb
+
 #  build-macos:
 #    runs-on: macos-10.15
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Aldor CI](https://github.com/gvanuxem/aldor/actions/workflows/ci.yaml/badge.svg)](https://github.com/gvanuxem/aldor/actions/workflows/ci.yaml)
+
 The Aldor Programming Language
 ==============================
 


### PR DESCRIPTION
Upload binaries such that it is available in the CIs Actions pages.
See for example, at the bottom of the page, https://github.com/fricas/fricas/actions/runs/12276733678

Feel free to upload only one package, here it uploads a zip file that contains the .tar.gz and .deb files.